### PR TITLE
CS-43946 - replaced version with _version for content-types and global fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "contentstack-cli-tsgen",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "contentstack-cli-tsgen",
-      "version": "2.3.1",
+      "version": "2.3.2",
       "license": "MIT",
       "dependencies": {
         "@contentstack/cli-command": "^1.2.17",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "contentstack-cli-tsgen",
   "description": "Generate TypeScript typings from a Stack.",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "author": "Michael Davis",
   "bugs": "https://github.com/Contentstack-Solutions/contentstack-cli-tsgen/issues",
   "dependencies": {

--- a/src/lib/tsgen/factory.ts
+++ b/src/lib/tsgen/factory.ts
@@ -240,7 +240,7 @@ export default function (userOptions: TSGenOptions) {
       define_interface(contentType, options.systemFields),
       '{',
       ['/**', "Version", '*/'].join(' '),
-      [`version: `,contentType._version,';'].join(' '),
+      [`_version: `,contentType._version,';'].join(' '),
       visit_fields(contentType.schema),
       '}',
     ]

--- a/tests/tsgen/boolean.test.ts
+++ b/tests/tsgen/boolean.test.ts
@@ -25,7 +25,7 @@ describe("builtin boolean field", () => {
       "export interface IBoolean
       {
       /** Version */
-      version:  2 ;
+      _version:  2 ;
       title: string  ;
       boolean?: boolean  ;
       }"

--- a/tests/tsgen/defaults.test.ts
+++ b/tests/tsgen/defaults.test.ts
@@ -18,7 +18,7 @@ describe("default single content block", () => {
       "export interface IMetadataSingleContentBlock
       {
       /** Version */
-      version:  2 ;
+      _version:  2 ;
       title: string  ;
       }"
     `);
@@ -44,7 +44,7 @@ describe("default single webpage", () => {
       "export interface IMetadataSingleWebpage
       {
       /** Version */
-      version:  2 ;
+      _version:  2 ;
       title: string  ;
       url: string  ;
       }"

--- a/tests/tsgen/global.fields.test.ts
+++ b/tests/tsgen/global.fields.test.ts
@@ -25,7 +25,7 @@ describe("global fields", () => {
       "export interface ISeo
       {
       /** Version */
-      version:   ;
+      _version:   ;
       keywords?: string  ;
       description?: string  ;
       }"
@@ -37,7 +37,7 @@ describe("global fields", () => {
       "export interface IGlobalFields
       {
       /** Version */
-      version:  2 ;
+      _version:  2 ;
       title: string  ;
       seo?: ISeo  ;
       }"

--- a/tests/tsgen/group.test.ts
+++ b/tests/tsgen/group.test.ts
@@ -24,7 +24,7 @@ describe("group", () => {
       "export interface Group
       {
       /** Version */
-      version:  3 ;
+      _version:  3 ;
       title: string  ;
       multiple_group_max_limit?: [{
       number?: number | null ;

--- a/tests/tsgen/isodate.test.ts
+++ b/tests/tsgen/isodate.test.ts
@@ -25,7 +25,7 @@ describe("builtin isodate field", () => {
       "export interface Isodate
       {
       /** Version */
-      version:  2 ;
+      _version:  2 ;
       title: string  ;
       date?: string | null ;
       date_required: string  ;

--- a/tests/tsgen/jsdoc.test.ts
+++ b/tests/tsgen/jsdoc.test.ts
@@ -16,7 +16,7 @@ describe("jsdoc", () => {
       export interface Jsdoc
       {
       /** Version */
-      version:  3 ;
+      _version:  3 ;
       /** Name */
       title: string  ;
       /** Age */

--- a/tests/tsgen/modular.blocks.test.ts
+++ b/tests/tsgen/modular.blocks.test.ts
@@ -21,7 +21,7 @@ describe("modular blocks", () => {
       "export interface ModularBlocks
       {
       /** Version */
-      version:  2 ;
+      _version:  2 ;
       title: string  ;
       url: string  ;
       modular_blocks?: ({string_block: {single_line?: string  ;

--- a/tests/tsgen/number.test.ts
+++ b/tests/tsgen/number.test.ts
@@ -22,7 +22,7 @@ describe("builtin number field", () => {
       "export interface Number
       {
       /** Version */
-      version:  2 ;
+      _version:  2 ;
       title: string  ;
       url: string  ;
       number?: number | null ;

--- a/tests/tsgen/options.test.ts
+++ b/tests/tsgen/options.test.ts
@@ -15,7 +15,7 @@ describe("all options", () => {
       "export interface Options
       {
       /** Version */
-      version:  4 ;
+      _version:  4 ;
       title: string  ;
       url: string  ;
       single_line_textbox_not_required?: string  ;

--- a/tests/tsgen/references.test.ts
+++ b/tests/tsgen/references.test.ts
@@ -26,7 +26,7 @@ describe("references", () => {
       "export interface IReferenceParent
       {
       /** Version */
-      version:  5 ;
+      _version:  5 ;
       title: string  ;
       url: string  ;
       single_reference: (IReferenceChild)[]  ;

--- a/tests/tsgen/select.test.ts
+++ b/tests/tsgen/select.test.ts
@@ -21,7 +21,7 @@ describe("select (dropdown)", () => {
       "export interface Select
       {
       /** Version */
-      version:  5 ;
+      _version:  5 ;
       title: string  ;
       select_single_value?: (\\"Option 1\\" | \\"Option 2\\" | \\"Option 3\\") | null ;
       select_single_value_required: (\\"Test 1\\" | \\"Test 2\\" | \\"Test 3\\")  ;

--- a/tests/tsgen/string.test.ts
+++ b/tests/tsgen/string.test.ts
@@ -22,7 +22,7 @@ describe("builtin string fields", () => {
       "export interface BuiltinStrings
       {
       /** Version */
-      version:  4 ;
+      _version:  4 ;
       title: string  ;
       single_line?: string  ;
       multi_line?: string  ;

--- a/tests/tsgen/taxonomies.test.ts
+++ b/tests/tsgen/taxonomies.test.ts
@@ -27,7 +27,7 @@ describe("builtin taxonomies field", () => {
       "export interface ITaxonomy
       {
       /** Version */
-      version:  2 ;
+      _version:  2 ;
       title: string  ;
       boolean?: boolean  ;
       taxonomies?: ITaxonomy[]  ;


### PR DESCRIPTION
version bump:
contentstack-cli-tsgen: 2.3.1 -> 2.3.2