### PR TITLE
Adds types for references when only returning uid and _content_type_uid

### DIFF
--- a/src/lib/stack/builtins.ts
+++ b/src/lib/stack/builtins.ts
@@ -7,7 +7,7 @@ export const defaultInterfaces = (prefix = '', systemFields = false) => {
             time: string;
             user: string;
         }`,
-        `export interface ${prefix}File { 
+        `export interface ${prefix}File {
               uid: string;
               created_at: string;
               updated_at: string;
@@ -25,11 +25,15 @@ export const defaultInterfaces = (prefix = '', systemFields = false) => {
               title: string;
               publish_details: ${prefix}PublishDetails;
           }`,
-        `export interface ${prefix}Link { 
+        `export interface ${prefix}Link {
               title: string;
               href: string;
           }`,
-        `export interface ${prefix}Taxonomy { 
+        `export interface ${prefix}Reference {
+              uid: string;
+              _content_type_uid: string;
+          }`,
+        `export interface ${prefix}Taxonomy {
             taxonomy_uid: string;
             max_terms?: number;
             mandatory: boolean;

--- a/src/lib/tsgen/factory.ts
+++ b/src/lib/tsgen/factory.ts
@@ -322,8 +322,12 @@ export default function (userOptions: TSGenOptions) {
     return name
   }
 
+  function type_reference_id() {
+    return `${options.naming?.prefix}Reference`
+  }
+
   function type_reference(field: ContentstackTypes.Field) {
-    const references: string[] = []
+    const references: string[] = [type_reference_id()]
 
     if (Array.isArray(field.reference_to)) {
       field.reference_to.forEach(v => {

--- a/tests/tsgen/references.test.ts
+++ b/tests/tsgen/references.test.ts
@@ -29,8 +29,8 @@ describe("references", () => {
       _version?:  5 ;
       title: string  ;
       url: string  ;
-      single_reference: (IReferenceChild)[]  ;
-      multiple_reference?: (IReferenceChild | IBoolean | IBuiltinExample)[]  ;
+      single_reference: (IReference | IReferenceChild)[]  ;
+      multiple_reference?: (IReference | IReferenceChild | IBoolean | IBuiltinExample)[]  ;
       }"
     `);
   });


### PR DESCRIPTION
For references, if `include[]` does not contain them, the API returns only `uid` and `_content_type_uid`, instead of the whole type. Currently only whole types are generated for references with tsgen. This PR adds another built-in type that only has `uid` and `_content_type_uid` to match the default returned type.